### PR TITLE
fixing PhoneGap Build tagging (#102 related)

### DIFF
--- a/blog/build/_posts/2011-07-14-multi-user-action.md
+++ b/blog/build/_posts/2011-07-14-multi-user-action.md
@@ -6,8 +6,6 @@ title: Hot Multi-User Action!
 date: Thu Jul 14 13:55:45 -0700 2011
 permalink: /blog/build/multi-user-action/
 ---
-tags:
-- PhoneGap Build
 
 Admin Dev Tester etc
 

--- a/blog/build/_posts/2011-10-25-public-pages.md
+++ b/blog/build/_posts/2011-10-25-public-pages.md
@@ -6,8 +6,6 @@ title: Public Pages
 date: Tue Oct 25 13:05:57 -0700 2011
 permalink: /blog/build/public-pages/
 ---
-tags:
-- PhoneGap Build
 We're happy to announce that public pages are now available for your apps on PhoneGap Build - any app you build on our site can now be easily distributed to clients, friends, enemies, or whoever, just through the power of the internet.
 
 To make an existing app public, just make the change on your app edit page and hit save:

--- a/blog/build/_posts/2012-02-21-childbrowser-plugin.md
+++ b/blog/build/_posts/2012-02-21-childbrowser-plugin.md
@@ -6,8 +6,6 @@ title: ChildBrowser Plugin
 date: Tue Feb 21 12:31:00 -0800 2012
 permalink: /blog/build/childbrowser-plugin/
 ---
-tags:
-- PhoneGap Build
 
 One of most highly demanded features on Adobe® PhoneGap™ Build has been support for PhoneGap Plugins, so we're happy to announce official support for the popular ChildBrowser plugin for Android and iOS - more details can be found in [the docs](/docs/plugins).
 

--- a/blog/build/_posts/2012-02-24-install-ios-apps-directly.md
+++ b/blog/build/_posts/2012-02-24-install-ios-apps-directly.md
@@ -6,8 +6,6 @@ title: Install iOS Apps Directly
 date: Fri Feb 24 09:33:25 -0800 2012
 permalink: /blog/build/install-ios-apps-directly/
 ---
-tags:
-- PhoneGap Build
 
 A small but much-demanded new feature for our iOS users to announce - you can now install Adobe® PhoneGap™ Build directly on your iOS devices, without syncing through iTunes or XCode!
 

--- a/blog/build/_posts/2012-03-20-access-tags.md
+++ b/blog/build/_posts/2012-03-20-access-tags.md
@@ -6,8 +6,6 @@ title: Access Tags
 date: Tue Mar 20 16:12:16 -0700 2012
 permalink: /blog/build/introducing-windows-phone-7-builds/
 ---
-tags:
-- PhoneGap Build
 There's been some confusion over the behavior of external links in PhoneGap™ (and Adobe® PhoneGap™ Build) apps lately - when you click on a link, should it take over your entire app? Or should it open in the device's browser?
 
 This is a bit of a tricky issue due to PhoneGap's use of a whitelist for allowed domains - developers need to explicitly allow any domains from which resources can be loaded. In theory, this is a good idea; however, the PhoneGap/Apache Cordova implementations have to deal with the webviews provided by native SDKs, and the control the open source project has over these webviews varies greatly from platform to platform.

--- a/blog/build/_posts/2012-04-19-introducing-windows-phone-7-builds.md
+++ b/blog/build/_posts/2012-04-19-introducing-windows-phone-7-builds.md
@@ -6,8 +6,6 @@ title: Introducing Windows Phone 7 Builds
 date: Thu Apr 19 13:13:57 -0700 2012
 permalink: /blog/build/introducing-windows-phone-7-builds/
 ---
-tags:
-- PhoneGap Build
 The Adobe® PhoneGap™ Build team is proud to introduce Windows® Phone 7 as our latest addition to our platform lineup.
 
 With the addition of Windows Phone 7, developers are now able to reach a new and rapidly growing market.

--- a/blog/build/_posts/2012-04-30-enhanced-icon-and-splash-support.md
+++ b/blog/build/_posts/2012-04-30-enhanced-icon-and-splash-support.md
@@ -6,8 +6,6 @@ title: Enhanced Icon and Splash Support
 date: Mon Apr 30 16:11:31 -0700 2012
 permalink: /blog/build/enhanced-icon-and-splash-support/
 ---
-tags:
-- PhoneGap Build
 We've recently had a lot of discussion with users about icons and splash screens
 and how they make their way into apps. After some feeback we've revamped our
 icon and splash screen handling to provide a more consistent and expressive

--- a/blog/build/_posts/2012-05-14-adobeid-and-github-integration.md
+++ b/blog/build/_posts/2012-05-14-adobeid-and-github-integration.md
@@ -6,8 +6,6 @@ title: Register and sign in with AdobeID and Github
 date: Mon May 14 09:16:42 -0700 2012
 permalink: /blog/build/adobeid-and-github-integration/
 ---
-tags:
-- PhoneGap Build
 
 Good news, folks - you can now [register](/people/sign_up) for Adobe® PhoneGap™ Build using your AdobeID or Github account. 
 

--- a/blog/build/_posts/2012-08-15-redesign.md
+++ b/blog/build/_posts/2012-08-15-redesign.md
@@ -6,8 +6,6 @@ title: Inside the redesign
 date: Wed Aug 15 09:16:42 -0700 2012
 permalink: /blog/build/redesign/
 ---
-tags:
-- PhoneGap Build
 
 Everyone's favourite thing just happened to Adobe® PhoneGap™ Build: a redesign! 
 

--- a/blog/build/_posts/2012-08-23-introducing-hydration.md
+++ b/blog/build/_posts/2012-08-23-introducing-hydration.md
@@ -6,8 +6,6 @@ title: Introducing Hydration
 date: Thu Aug 23 10:38:56 -0700 2012
 permalink: /blog/build/introducing-hydration/
 ---
-tags:
-- PhoneGap Build
 
 The PhoneGap Build team would like to introduce our latest feature -
 Hydration.

--- a/blog/build/_posts/2012-09-21-building-from-your-private-github-repositories.md
+++ b/blog/build/_posts/2012-09-21-building-from-your-private-github-repositories.md
@@ -6,8 +6,6 @@ title: Building from your Private Github Repositories
 date: Fri Sep 21 15:36:03 -0700 2012
 permalink: /blog/build/building-from-your-private-github-repositories/
 ---
-tags:
-- PhoneGap Build
 So, all these socialist open-source evangelists make you want to punch a kitten and fire someone. You want your source code
 private. But you still want to pull your app from Github to PhoneGap Build (and build using open-source
 project PhoneGap). Well, now you can.

--- a/blog/build/_posts/2012-10-01-retiring-git-phonegap-com.md
+++ b/blog/build/_posts/2012-10-01-retiring-git-phonegap-com.md
@@ -6,8 +6,6 @@ title: Retiring git.phonegap.com
 date: Mon Oct 01 10:00:00 -0700 2012
 permalink: /blog/build/retiring-git-phonegap-com/
 ---
-tags:
-- PhoneGap Build
 We're announcing today that our git hosting service, available at 
 `git.phonegap.com`, will be shut-down on December 1 this year, in two months. We
 will be disabling support for creating new apps linked to `git.phonegap.com` in

--- a/blog/build/_posts/2012-10-24-barcodescanner-plugin.md
+++ b/blog/build/_posts/2012-10-24-barcodescanner-plugin.md
@@ -6,8 +6,6 @@ title: BarcodeScanner Plugin
 date: Wed Oct 24 14:17:40 -0700 2012
 permalink: /blog/build/barcodescanner-plugin/
 ---
-tags:
-- PhoneGap Build
 We've added support for another plugin to Adobe® PhoneGap™ Build for iOS and Android -- BarcodeScanner. And more are coming!
 
 A single line of JavaScript in your PhoneGap app will launch the scanner, and upon detection of a barcode, control will be passed back to your app, along with the barcode data.

--- a/blog/build/_posts/2012-10-31-analytics-plugin.md
+++ b/blog/build/_posts/2012-10-31-analytics-plugin.md
@@ -6,8 +6,6 @@ title: Adobe® PhoneGap™ Build™ plugin for Google Analytics
 date: Wed Oct 31 13:08:40 -0700 2012
 permalink: /blog/build/analytics-plugin/
 ---
-tags:
-- PhoneGap Build
 We've added support for another plugin to Adobe® PhoneGap™ Build™ for iOS and Android --  Adobe® PhoneGap™ Build™ plugin for Google Analytics. And more are coming!
 
 You can log events, variables and page hits to your Google Analytics account and evaluate them in your dashboard.

--- a/blog/build/_posts/2012-11-07-upcoming-security-changes.md
+++ b/blog/build/_posts/2012-11-07-upcoming-security-changes.md
@@ -6,8 +6,6 @@ title: Upcoming Security Changes
 date: Wed Nov 07 11:49:46 -0700 2012
 permalink: /blog/build/upcoming-security-changes/
 ---
-tags:
-- PhoneGap Build
 Hi everyone,
 
 We're making some small changes to how we handle signing keys on PhoneGap Build,

--- a/blog/build/_posts/2013-01-15-phonegap-build-api-for-node.md
+++ b/blog/build/_posts/2013-01-15-phonegap-build-api-for-node.md
@@ -6,8 +6,6 @@ title: PhoneGap Build API for Node.js
 date: Tue Jan 15 11:39:27 -0800 2013
 permalink: /blog/build/phonegap-build-api-for-node/
 ---
-tags:
-- PhoneGap Build
 
 [Adobe PhoneGap Build](http://build.phonegap.com/) has a powerful [RESTful API](http://build.phonegap.com/docs/api) that you can use to tap into PhoneGap Build's functionality. With the API, you can authenticate as a user and create, build, update, and download PhoneGap applications.
 

--- a/blog/build/_posts/2013-01-18-my-first-mobile-game-in-html-with-phonegap-build.md
+++ b/blog/build/_posts/2013-01-18-my-first-mobile-game-in-html-with-phonegap-build.md
@@ -6,8 +6,6 @@ title: My First Mobile Game in HTML with PhoneGap Build
 date: Fri Jan 18 11:39:05 -0800 2013
 permalink: /blog/build/my-first-mobile-game-in-html-with-phonegap-build/
 ---
-tags:
-- PhoneGap Build
 
 In this post, I'll explain how I created a simple puzzle-game in HTML then turned it into an Android app.
 

--- a/blog/build/_posts/2013-01-21-status-update-jan-13---jan-19-2013.md
+++ b/blog/build/_posts/2013-01-21-status-update-jan-13---jan-19-2013.md
@@ -8,8 +8,6 @@ permalink: /blog/build/status-update-jan-13---
 tags:
 - PhoneGap Buildjan-19-2013/
 ---
-tags:
-- PhoneGap Build
 
 Hey Build users! We've got some exciting news. Some of you have
 expressed that we need to be more transparent in our progress towards

--- a/blog/build/_posts/2013-01-24-introducing-genericpush-plugin.md
+++ b/blog/build/_posts/2013-01-24-introducing-genericpush-plugin.md
@@ -6,8 +6,6 @@ title: Introducing GenericPush Plugin
 date: Thu Jan 24 14:17:30 -0800 2013
 permalink: /blog/build/introducing-genericpush-plugin/
 ---
-tags:
-- PhoneGap Build
 
 We're happy to announce the support of a new plugin! The
 [GenericPush plugin](https://github.com/phonegap-build/PushPlugin) is

--- a/blog/build/_posts/2013-01-28-status-update-jan-20---jan-26-2013.md
+++ b/blog/build/_posts/2013-01-28-status-update-jan-20---jan-26-2013.md
@@ -8,8 +8,6 @@ permalink: /blog/build/status-update-jan-20---
 tags:
 - PhoneGap Buildjan-26-2013/
 ---
-tags:
-- PhoneGap Build
 Hey Build users! It's time for our weekly update again. Here is what we've been up to.
 
 **Progress for Jan 20 - Jan 26**

--- a/blog/build/_posts/2013-01-29-adobe-phonegap-build-plugin-for-facebook-connect.md
+++ b/blog/build/_posts/2013-01-29-adobe-phonegap-build-plugin-for-facebook-connect.md
@@ -6,8 +6,6 @@ title: Adobe PhoneGap Build plugin for Facebook Connect
 date: Tue Jan 29 13:34:38 -0800 2013
 permalink: /blog/build/adobe-phonegap-build-plugin-for-facebook-connect/
 ---
-tags:
-- PhoneGap Build
 
 Last week we released the [GenericPush Plugin](https://build.phonegap.com/blog/introducing-genericpush-plugin) and this week we're excited to introduce another plugin to the line up: [Adobe® PhoneGap™ Build™ plugin for Facebook Connect](https://github.com/phonegap-build/FacebookConnect).
 

--- a/blog/build/_posts/2013-02-06-status-update-jan-27---feb-4-2013.md
+++ b/blog/build/_posts/2013-02-06-status-update-jan-27---feb-4-2013.md
@@ -8,8 +8,6 @@ permalink: /blog/build/status-update-jan-27---
 tags:
 - PhoneGap Buildfeb-4-2013/
 ---
-tags:
-- PhoneGap Build
 
 Hey everyone, this post is a bit late as we were hard at work on the 2.3.0 release. We hope you'll forgive us for our tardiness!
 

--- a/blog/build/_posts/2013-02-15-status-update-feb-5---feb-12-2013.md
+++ b/blog/build/_posts/2013-02-15-status-update-feb-5---feb-12-2013.md
@@ -8,8 +8,6 @@ permalink: /blog/build/status-update-feb-5---
 tags:
 - PhoneGap Buildfeb-12-2013/
 ---
-tags:
-- PhoneGap Build
 
 We made some great progress last week! Here's what we were busy with last
 week, and what's going to keep us busy in the coming weeks.

--- a/blog/build/_posts/2013-02-18-getting-started-with-phonegap-and-phonegap-build.md
+++ b/blog/build/_posts/2013-02-18-getting-started-with-phonegap-and-phonegap-build.md
@@ -12,8 +12,6 @@ tags:
 - PhoneGap Build
 - Tutorial
 ---
-tags:
-- PhoneGap Build
 
 Are you brand new to PhoneGap? Where do you start?  What about PhoneGap Build? There are a ton of resources out there and I’ve pulled it all together to help you get started, get some tips, and figure out where to get help.
 

--- a/blog/build/_posts/2013-03-18-status-update-mar-04---mar-18-2013.md
+++ b/blog/build/_posts/2013-03-18-status-update-mar-04---mar-18-2013.md
@@ -8,8 +8,6 @@ permalink: /blog/build/tatus-update-mar-04---
 tags:
 - PhoneGap Buildmar-18-2013/
 ---
-tags:
-- PhoneGap Build
 
 Hey Build users! We've been working hard on Build over the last couple
 weeks. The progress we've made should help us provide a better user

--- a/blog/build/_posts/2013-04-09-phonegap-2-5-support.md
+++ b/blog/build/_posts/2013-04-09-phonegap-2-5-support.md
@@ -10,8 +10,6 @@ tags:
 - News
 - Release
 ---
-tags:
-- PhoneGap Build
 
 Great news, the PhoneGap Build team has been working hard and we now support PhoneGap 2.5.0. Happy building!
 

--- a/blog/build/_posts/2013-04-26-new-apple-app-store-submittal-rules.md
+++ b/blog/build/_posts/2013-04-26-new-apple-app-store-submittal-rules.md
@@ -6,8 +6,6 @@ title: New Apple App Store Submittal Rules
 date: Fri Apr 26 15:11:22 -0700 2013
 permalink: /blog/build/new-apple-app-store-submittal-rules/
 ---
-tags:
-- PhoneGap Build
 
 Beginning on May 1, all PhoneGap Build iOS apps submitted to the Apple App store must be built with PhoneGap __2.5.0 or above__.
 

--- a/blog/build/_posts/2013-04-29-ending-support-for-phonegap-1-9.md
+++ b/blog/build/_posts/2013-04-29-ending-support-for-phonegap-1-9.md
@@ -6,8 +6,6 @@ title: Ending Support for PhoneGap 1.9 and Below on PG Build
 date: Mon Apr 29 17:27:39 -0700 2013
 permalink: /blog/build/ending-support-for-phonegap-1-9/
 ---
-tags:
-- PhoneGap Build
 In an effort to focus the efforts of the PhoneGap Build development team, we will be ending support for all PhoneGap versions prior to 2.0 with our upcoming release of Phonegap 2.7. We're currently aiming to release 2.7 around May 15.
 
 With the evolution of PhoneGap since 1.x, the [Cordova](http://cordova.apache.org/) architecture has gone through numerous improvements and redesigns. Removing support for 1.9 and earlier will allow us to simplify our infrastructure and improve the performance of PhoneGap Build.

--- a/blog/build/_posts/2013-05-09-important-update-to-Google-Analytics-Plugin.md
+++ b/blog/build/_posts/2013-05-09-important-update-to-Google-Analytics-Plugin.md
@@ -6,8 +6,6 @@ title: Important Update to Google Analytics Plugin
 date: Thu May 9 16:00:39 -0700 2013
 permalink: /blog/build/important-update-to-Google-Analytics-Plugin/
 ---
-tags:
-- PhoneGap Build
 
 Google has recently deprecated version 1 of the Google Analytics SDK, on which GAPlugin was based. Accordingly, we have updated the plugin to use Google Analytics SDK v2. We have attempted to maintain backwards compatibility with the v1 plugin. However, depending on your usage, you **may** need to make some minor changes to your App.
 

--- a/blog/build/_posts/2013-05-21-phonegap-2-7-0-now-on-build.md
+++ b/blog/build/_posts/2013-05-21-phonegap-2-7-0-now-on-build.md
@@ -6,8 +6,6 @@ author: Ryan Willoughby
 title: "PhoneGap 2.7.0 now on Build"
 permalink: /blog/build/phonegap-2-7-0-now-on-build/
 ---
-tags:
-- PhoneGap Build
 
 Great news, we've pushed 2.7.0 support to PhoneGap Build! With this release we're deprecating anything less than PhoneGap 2.0.0. Check out [the blog post where 'we told you so'](http://build.phonegap.com/blog/ending-support-for-phonegap-1-9) for more info on why.
 

--- a/blog/build/_posts/2013-05-31-congrats-to-our-phonegap-build-champions.md
+++ b/blog/build/_posts/2013-05-31-congrats-to-our-phonegap-build-champions.md
@@ -6,8 +6,6 @@ title: Congrats to our PhoneGap Build Champions
 date: Fri May 31 10:10:26 -0700 2013
 permalink: /blog/build/congrats-to-our-phonegap-build-champions/
 ---
-tags:
-- PhoneGap Build
 
 PhoneGap Build users looking for support head to our free forum hosted over on [Get Satisfaction](http://getsatisfaction.com/nitobi/products/nitobi_phonegap_build). If you've ever been on the forum, you've probably seen some people who go above and beyond by helping others. They're not PhoneGap Build staff, but fellow Build users who are passionate about the service and like to help the community.
 

--- a/blog/build/_posts/2013-05-31-improving-build-one-step-at-a-time.md
+++ b/blog/build/_posts/2013-05-31-improving-build-one-step-at-a-time.md
@@ -6,8 +6,6 @@ title: Improving Build One Step at a Time
 date: Fri May 31 10:01:47 -0700 2013
 permalink: /blog/build/improving-build-one-step-at-a-time/
 ---
-tags:
-- PhoneGap Build
 
 Hey friends,
 

--- a/blog/build/_posts/2013-06-27-phonegap-2-9-now-on-build.md
+++ b/blog/build/_posts/2013-06-27-phonegap-2-9-now-on-build.md
@@ -7,8 +7,6 @@ title: PhoneGap 2.9.0 Now on Build
 date: Thu Jun 27 13:33:35 -0700 2013
 permalink: /blog/build/phonegap-2-9-now-on-build/
 ---
-tags:
-- PhoneGap Build
 
 We've just added support for [PhoneGap 2.9.0](http://phonegap.com/blog/2013/06/26/pg-290-released/) to PhoneGap Build! 
 

--- a/blog/build/_posts/2013-07-03-build-june-summary-post.md
+++ b/blog/build/_posts/2013-07-03-build-june-summary-post.md
@@ -6,8 +6,6 @@ author: Mike Harris
 title: "Build June Summary"
 category: build
 ---
-tags:
-- PhoneGap Build
 
 #Highlights for June
 + Alignment with Cordova using Plugman for plugin registration

--- a/blog/build/_posts/2013-07-15-using-plugins-with-phonegapbuild.md
+++ b/blog/build/_posts/2013-07-15-using-plugins-with-phonegapbuild.md
@@ -6,8 +6,6 @@ author: Mike Harris
 title: "Using Plugins with PhoneGap Build"
 category: build
 ---
-tags:
-- PhoneGap Build
 
 In the near future, we will be releasing a new feature that allows users to submit online their own plugins to PhoneGap Build. These submitted plugins will be available for the whole community to use. 
 

--- a/blog/build/_posts/2013-07-16-user-submitted-plugins-announcement-post.md
+++ b/blog/build/_posts/2013-07-16-user-submitted-plugins-announcement-post.md
@@ -6,8 +6,6 @@ author: Don Woodward
 title: "PhoneGap Build now supports User Submitted Plugins!"
 category: build
 ---
-tags:
-- PhoneGap Build
 
 We are pleased to announce the availability of a new PhoneGap Build feature called **User Submitted Plugins**.  This new feature allows you to submit plugins for public use on PhoneGap Build.  Any plugin may be submitted, and once approved, becomes available for the entire PhoneGap Build community to enjoy.
 

--- a/blog/build/_posts/2013-08-12-build-august-update.md
+++ b/blog/build/_posts/2013-08-12-build-august-update.md
@@ -6,8 +6,6 @@ author: Mike Harris
 title: "August Build Update"
 category: build
 ---
-tags:
-- PhoneGap Build
 
 In July we had two major updates - [user submitted plugins](http://phonegap.com/blog/2013/07/16/user-submitted-plugins-announcement-post/) and support for Japanese. We also had an incredibly successful PhoneGap Day in July - more details [here](http://phonegap.com/blog/2013/08/02/a-look-back-at-pgday-us/). Coming up next is [PhoneGap Day EU](http://pgday.phonegap.com/eu2013/) on September 24th in Amsterdam and PhoneGap Day BR on November 26 in Rio de Janeiro.
 

--- a/blog/build/_posts/2013-09-18-deprecation-of-2-3-0-and-below.md
+++ b/blog/build/_posts/2013-09-18-deprecation-of-2-3-0-and-below.md
@@ -6,8 +6,6 @@ author: Ryan Willoughby
 title: "Upcoming Deprecation of Cordova 2.3.0 and Below on Build"
 category: build
 ---
-tags:
-- PhoneGap Build
 
 We're hard at work finishing up support for Cordova 3.0.0 on PhoneGap Build, and with new life, comes death, or something. We'll be deprecating **Cordova 2.3.0 and below** with our upcoming release of 3.0.0. This is our heads up!
 

--- a/blog/build/_posts/2013-09-20-phonegap-and-tripcase.md
+++ b/blog/build/_posts/2013-09-20-phonegap-and-tripcase.md
@@ -10,8 +10,6 @@ tags:
 - Community
 - PhoneGap Build
 ---
-tags:
-- PhoneGap Build
 
 If you travel a lot, you need to check out [TripCase](http://travel.tripcase.com/), a free web and mobile app for travelers built for Apple and Android platforms using several developer tools, with PhoneGap playing a leading role. Created by travel technology giant Sabre, TripCase integrates with Sabre’s global distribution system so your itinerary—including flights, hotels, ground transport, activities, restaurants, meetings, and more—is automatically populated the app.
  

--- a/blog/build/_posts/2013-10-01-phonegap-30-now-supported.md
+++ b/blog/build/_posts/2013-10-01-phonegap-30-now-supported.md
@@ -6,8 +6,6 @@ author: Ryan Stewart
 title: "PhoneGap 3.0 Now Supported in PhoneGap Build"
 category: build
 ---
-tags:
-- PhoneGap Build
 
 PhoneGap 3.0 is now available as a build target in PhoneGap Build! You can start using 3.0 by specifying it in your config.xml file by using the `phonegap-version` preference:
 

--- a/blog/build/_posts/2013-10-18-2013-10-18-phonegap-build-support-for-windows-phone-8.md
+++ b/blog/build/_posts/2013-10-18-2013-10-18-phonegap-build-support-for-windows-phone-8.md
@@ -6,8 +6,6 @@ author: Mike Harris
 title: "PhoneGap Build beta support for Windows Phone 8"
 category: build
 ---
-tags:
-- PhoneGap Build
 
 We are very pleased to announce a beta release of PhoneGap Build that supports Windows Phone 8 and Cordova 3.0. We welcome you to try building Windows Phone 8 applications with this new version of PhoneGap Build and deploy to you devices.
 

--- a/blog/build/_posts/2013-10-24-cordova-3_1-now-on-build.md
+++ b/blog/build/_posts/2013-10-24-cordova-3_1-now-on-build.md
@@ -6,8 +6,6 @@ author: Ryan Willoughby
 title: "Cordova 3.1.0 Now on PhoneGap Build"
 category: build
 ---
-tags:
-- PhoneGap Build
 
 [PhoneGap Build](http://build.phonegap.com) is happy to announce that we now support Cordova 3.1.0. For more info on what's included in 
 this update, check out the [Cordova 3.1.0 release blog post](http://cordova.apache.org/blog/releases/2013/10/02/cordova-31.html).

--- a/blog/build/_posts/2013-10-28-october-build-update.md
+++ b/blog/build/_posts/2013-10-28-october-build-update.md
@@ -6,8 +6,6 @@ author: Mike Harris
 title: "October Build Update"
 category: build
 ---
-tags:
-- PhoneGap Build
 
 In addition to providing support for Cordova 3.0, 3.1 and Windows Phone 8 platform, we've also been able to tackle:
 

--- a/blog/build/_posts/2013-11-04-plugin-submission-guidelines.md
+++ b/blog/build/_posts/2013-11-04-plugin-submission-guidelines.md
@@ -9,8 +9,6 @@ tags:
 - PhoneGap Build
 - Plugin
 ---
-tags:
-- PhoneGap Build
 
 One of the new features that's been added to PhoneGap Build in the past couple of months is the ability to submit custom [PhoneGap plugins](https://build.phonegap.com/plugins/) that you and others can use within PhoneGap Build projects. Once a plugin is submitted and approved, it becomes available to everyone using PhoneGap Build. For security and legal reasons, every plugin must adhere to specific standards and is hand-tested by the engineering team before it's approved and available to use in PhoneGap Build projects. We currently have over 30 user-submitted plugins available in PhoneGap Build.
 

--- a/blog/build/_posts/2013-11-14-bigger-apps-have-arrived.md
+++ b/blog/build/_posts/2013-11-14-bigger-apps-have-arrived.md
@@ -6,8 +6,6 @@ author: Colene Chow
 title: "Bigger Apps have Arrived"
 category: build
 ---
-tags:
-- PhoneGap Build
 
 The PhoneGap Build team is happy to announce the **increase of file sizes to 40MB for paid users of PhoneGap Build**.
 

--- a/blog/build/_posts/2014-01-23-recent-service-outages.md
+++ b/blog/build/_posts/2014-01-23-recent-service-outages.md
@@ -6,8 +6,6 @@ author: hardeep
 title: "Recent Service Outages"
 category: build
 ---
-tags:
-- PhoneGap Build
 
 What a week for PhoneGap Build! We've been having issues with our servers and experienced two days of extremely sluggish performance on our iOS servers, as well as on Hydration and Android servers. In the last couple days, we suffered a set of DB locks during out of office hours and even more sluggish performance on iOS.
 

--- a/blog/build/_posts/2014-01-28-cordova-3_3-now-on-build.md
+++ b/blog/build/_posts/2014-01-28-cordova-3_3-now-on-build.md
@@ -6,8 +6,6 @@ author: Ryan Willoughby
 title: "Cordova 3.3.0 Now on PhoneGap Build"
 category: build
 ---
-tags:
-- PhoneGap Build
 
 Now that our holiday shakes are finally gone, [PhoneGap Build](http://build.phonegap.com) can release Cordova 3.3.0! Here's more info on what's included:
 

--- a/blog/build/_posts/2014-01-30-customizing-your-android-manifest-and-ios-property-list-on-phonegap-build.md
+++ b/blog/build/_posts/2014-01-30-customizing-your-android-manifest-and-ios-property-list-on-phonegap-build.md
@@ -6,8 +6,6 @@ author: Ryan Willoughby
 title: "Customizing your Android Manifest and iOS Property List on PhoneGap Build"
 category: build
 ---
-tags:
-- PhoneGap Build
 
 PhoneGap Build aims to take away the pains of configuring SDKs and compiling native applications so you can focus on writing great code. As part of this, we obfuscate management of the platform configuration files -- namely your [Android Manifest](http://developer.android.com/guide/topics/manifest/manifest-intro.html) and your [iOS Property List](https://developer.apple.com/library/iOS/documentation/General/Reference/InfoPlistKeyReference/Articles/AboutInformationPropertyListFiles.html). We configure these files based on the preferences you specify in your app's config.xml file. However, the specifications of these xml files are constantly changing, and it would be impossible for us to expose all of the possible configurations through the use of simple preferences. So for those cases that we haven't covered, we're now enabling you to contribute xml directly to your Android Manifest and iOS Propertly List files, via the `gap:config-file` element (beta feature).
 

--- a/blog/build/_posts/2014-02-21-platform-deprecation.md
+++ b/blog/build/_posts/2014-02-21-platform-deprecation.md
@@ -6,8 +6,6 @@ author: Dave Johnson
 title: "Platform Deprecation"
 category: build
 ---
-tags:
-- PhoneGap Build
 
 It’s been almost a year since PhoneGap announced they would be [dropping support](http://phonegap.com/blog/2013/05/16/cordova-will-no-longer-support-bb/) for some platforms in versions of PhoneGap over 3.0. PhoneGap Build has [done the same](http://community.phonegap.com/nitobi/topics/blackberry_symbian_and_webos_will_not_be_supported_by_phonegap_3_0) and is not supporting webOS, Symbian or Blackberry (<= BB7) for apps using PhoneGap versions over 3.0.
 

--- a/blog/build/_posts/2014-03-18-removing-ios-sdk-6_1-on-phonegap-build.md
+++ b/blog/build/_posts/2014-03-18-removing-ios-sdk-6_1-on-phonegap-build.md
@@ -6,8 +6,6 @@ author: Ryan Willoughby
 title: "Deprecation and Removal of iOS SDK 6.1 on PhoneGap Build"
 category: build
 ---
-tags:
-- PhoneGap Build
 
 [From Apple](https://developer.apple.com/news/index.php?id=12172013a): 
 > As of February 1, new apps and app updates submitted to the App Store must be built with the latest version of Xcode 5 and must be optimized for iOS 7.

--- a/blog/build/_posts/2014-04-01-creating-a-top-5-fitness-app-with-phonebapbuild .md
+++ b/blog/build/_posts/2014-04-01-creating-a-top-5-fitness-app-with-phonebapbuild .md
@@ -9,8 +9,6 @@ tags:
 - Guest Post
 - PhoneGap Build
 ---
-tags:
-- PhoneGap Build
 
 Fitbit creates wireless activity trackers that empower people to live healthier lives. My new mobile app, Fitwatchr, allows Fitbit users to combine their daily calorie tracking features with scientific formulas, motivating them to lose weight, earn extra calories, and achieve their weight loss goals. It is available on [iOS](http://appstore.com/fitwatchr) and [Android](https://play.google.com/store/apps/details?id=com.netkow.fitwatchr).
  

--- a/blog/build/_posts/2014-04-01-creating-a-top-5-fitness-app-with-phonegapbuild.md
+++ b/blog/build/_posts/2014-04-01-creating-a-top-5-fitness-app-with-phonegapbuild.md
@@ -9,8 +9,6 @@ tags:
 - Guest Post
 - PhoneGap Build
 ---
-tags:
-- PhoneGap Build
 
 Fitbit creates wireless activity trackers that empower people to live healthier lives. My new mobile app, Fitwatchr, allows Fitbit users to combine their daily calorie tracking features with scientific formulas, motivating them to lose weight, earn extra calories, and achieve their weight loss goals. It is available on [iOS](http://appstore.com/fitwatchr) and [Android](https://play.google.com/store/apps/details?id=com.netkow.fitwatchr).
  

--- a/blog/build/_posts/2014-04-07-cordova-3_4-now-on-build.md
+++ b/blog/build/_posts/2014-04-07-cordova-3_4-now-on-build.md
@@ -6,8 +6,6 @@ author: Ryan Willoughby
 title: "Cordova 3.4.0 Now on PhoneGap Build"
 category: build
 ---
-tags:
-- PhoneGap Build
 
 [PhoneGap Build](http://build.phonegap.com) has added Cordova 3.4.0! Here's more info on what's included:
 

--- a/blog/build/_posts/2014-04-11-phonegap-build-adds-some-new-features.md
+++ b/blog/build/_posts/2014-04-11-phonegap-build-adds-some-new-features.md
@@ -6,8 +6,6 @@ author: Brett Rudd
 title: "PhoneGap Build Adds Some New Features!"
 category: build
 ---
-tags:
-- PhoneGap Build
 
 Hi. I'm Brett (@brettrudd) from the build team and i'm happy to announce a few new features that have been deployed to build in the last week.
 

--- a/blog/build/_posts/2014-04-16-removing-legacy-logins.md
+++ b/blog/build/_posts/2014-04-16-removing-legacy-logins.md
@@ -6,8 +6,6 @@ author: Brett Rudd
 title: "How You Sign into PhoneGap Build is Changing."
 category: build
 ---
-tags:
-- PhoneGap Build
 
 On May 15th we will be removing the ability to sign into our service without
 either a GitHub or Adobe ID. This is to simplify authentication and

--- a/blog/build/_posts/2014-06-17-building-your-app-from-a-git-branch-or-tag.md
+++ b/blog/build/_posts/2014-06-17-building-your-app-from-a-git-branch-or-tag.md
@@ -6,8 +6,6 @@ author: Ryan Willoughby
 title: "Building Your App from a Git Branch or Tag"
 category: build
 ---
-tags:
-- PhoneGap Build
 
 After numerous requests, handwritten letters, two faxes, and a telegraph asking for support for building from app tags and branches, we listened -- its now supported on PhoneGap Build. You'll find the new field in the New App form -- simply enter the branch or tag name in the field next to _repo_. If you're using the [Developer API](http://docs.build.phonegap.com/en_US/developer_api_api.md.html), add a _tag_ field in addition to the _repo url_:
 

--- a/blog/build/_posts/2014-06-19-oauth-and-the-phonegap-build-developer-api.md
+++ b/blog/build/_posts/2014-06-19-oauth-and-the-phonegap-build-developer-api.md
@@ -6,8 +6,6 @@ author: Ryan Willoughby
 title: "OAuth and the PhoneGap Build Developer API"
 category: build
 ---
-tags:
-- PhoneGap Build
 
 Some news for you devs using the PhoneGap Build Developer API\: we've added support for the OAuth authentication protocol. Up to now, API developers wishing to authenticate against the API would use basic authentication to obtain an auth token, and use that token to access the API. However, this meant that client applications had to ask for the user's PhoneGap Build username and password, which from a security perspective isn't ideal. With OAuth, client applications will now send their users to PhoneGap Build to authenticate their credentials, and authorize the client to access PhoneGap Build on their behalf.
 

--- a/blog/build/_posts/2014-07-17-cordova-3_5-now-on-build.md
+++ b/blog/build/_posts/2014-07-17-cordova-3_5-now-on-build.md
@@ -6,8 +6,6 @@ author: Ryan Willoughby
 title: "Cordova 3.5.0 Now on PhoneGap Build"
 category: build
 ---
-tags:
-- PhoneGap Build
 
 [PhoneGap Build](http://build.phonegap.com) has added support for Cordova 3.5.0. For more info about this release, check out these handy links:
 

--- a/blog/build/_posts/2014-08-07-cordova-android-3_5_0-patched-with-security-fixes.md
+++ b/blog/build/_posts/2014-08-07-cordova-android-3_5_0-patched-with-security-fixes.md
@@ -6,8 +6,6 @@ author: Ryan Willoughby
 title: "Cordova Android 3.5.0 Patched With Security Updates"
 category: build
 ---
-tags:
-- PhoneGap Build
 
 The Apache Cordova Project recently released Cordova 3.5.1, a patch for Cordova Android only. It contains a few very important security updates. On PhoneGap Build, rather than add 3.5.1, we've patched our Cordova Android 3.5.0 release with the security updates. For more information on the security updates, check out the [Apache Cordova blog post](http://cordova.apache.org/announcements/2014/08/04/android-351.html).
 

--- a/blog/build/_posts/2014-08-12-adobeid-required.md
+++ b/blog/build/_posts/2014-08-12-adobeid-required.md
@@ -6,8 +6,6 @@ author: Brett Rudd
 title: "Adobe ID now required for PhoneGap Build"
 category: build
 ---
-tags:
-- PhoneGap Build
 
 As part of our continued integration with the expanding ecosystem of Adobe's
 Creative Cloud we now require all PhoneGap Build users to link their accounts

--- a/blog/build/_posts/2014-09-30-phonegap-3_6_3-now-on-build.md
+++ b/blog/build/_posts/2014-09-30-phonegap-3_6_3-now-on-build.md
@@ -6,8 +6,6 @@ author: Ryan Willoughby
 title: "Phonegap 3.6.3 is Now Available on Phonegap Build"
 category: build
 ---
-tags:
-- PhoneGap Build
 
 We've made Phonegap / Cordova 3.6.3 available on Phonegap Build - upgrade now! For more details on what's changed, check out the [Apache Cordova 3.6 release blog post](http://cordova.apache.org/announcements/2014/09/22/cordova-361.html). In addition, we've recently updated to the latest versions of all core plugins on Phonegap Build -- [more details here](http://community.phonegap.com/nitobi/topics/core-plugins-have-been-updated-on-phonegap-build).
 

--- a/blog/build/_posts/2014-10-01-upcoming-deprecations.md
+++ b/blog/build/_posts/2014-10-01-upcoming-deprecations.md
@@ -6,8 +6,6 @@ author: Brett Rudd @brettrudd
 title: "Cordova 2.9, WebOS, Symbian, Blackberry and Windows Phone 7 Deprecations"
 category: build
 ---
-tags:
-- PhoneGap Build
 
 On October 15th, 2014 we will be removing support for WebOS, Symbian, Blackberry
 and Windows Phone 7 platforms, as well as for all Cordova versions below 3.0.

--- a/blog/build/_posts/2014-12-09-phonegap-build-new-features.md
+++ b/blog/build/_posts/2014-12-09-phonegap-build-new-features.md
@@ -8,8 +8,6 @@ category: build
 tags:
 - PhoneGap Build Blog
 ---
-tags:
-- PhoneGap Build
 
 The PhoneGap Build team is excited to announce some big changes all designed to make your dev life easier. Say goodbye to plugin restrictions and no more waiting for reviews and approvals. 
 

--- a/blog/build/_posts/2015-01-20-ios-64bit-support.md
+++ b/blog/build/_posts/2015-01-20-ios-64bit-support.md
@@ -6,8 +6,6 @@ author: brettrudd
 title: "iOS 64-bit Support Now Available on PhoneGap Build"
 category: build
 ---
-tags:
-- PhoneGap Build
 
 Starting today iOS builds using **PhoneGap 3.5.0** and above will now include the
 arm64 (64-bit) architecture as required by all new apps on the Apple App Store

--- a/blog/build/_posts/2015-01-27-hydration-now-available-for-windows-phone-8-on-build.md
+++ b/blog/build/_posts/2015-01-27-hydration-now-available-for-windows-phone-8-on-build.md
@@ -6,8 +6,6 @@ author: Ryan Willoughby
 title: "Hydration Now Available for Windows Phone 8 on Build"
 category: build
 ---
-tags:
-- PhoneGap Build
 
 Good news, you can finally hydrate your Windows Phone 8 apps on PhoneGap build!
 

--- a/blog/build/_posts/2015-02-17-phonegap-3_7_0-now-on-build.md
+++ b/blog/build/_posts/2015-02-17-phonegap-3_7_0-now-on-build.md
@@ -6,8 +6,6 @@ author: Ryan Willoughby
 title: "PhoneGap 3.7.0 Now Available on PhoneGap Build"
 category: build
 ---
-tags:
-- PhoneGap Build
 
 PhoneGap 3.7.0 is now available on PhoneGap Build! For more details on the update:
 

--- a/blog/build/_posts/2015-05-26-npm-plugins-available.md
+++ b/blog/build/_posts/2015-05-26-npm-plugins-available.md
@@ -7,8 +7,6 @@ author: brettrudd
 title: "npm Plugins Are Now on PhoneGap Build!"
 category: build
 ---
-tags:
-- PhoneGap Build
 
 As announced in this [blog post](http://cordova.apache.org/announcements/2015/04/21/plugins-release-and-move-to-npm.html),
 cordova has moved it's official plugin source to the [npmjs.com](https://www.npmjs.com) repository. As part of this move [plugins.cordova.io](http://plugins.cordova.io)

--- a/blog/build/_posts/2015-06-16-phonegap-updated-on-build.md
+++ b/blog/build/_posts/2015-06-16-phonegap-updated-on-build.md
@@ -6,8 +6,6 @@ author: Ryan Willoughby
 title: "Cordova 5.1.1 Now on PhoneGap Build"
 category: build
 ---
-tags:
-- PhoneGap Build
 
 We're happy to let you know that we've updated PhoneGap for iOS, Android, and Windows Phone on PhoneGap Build. The latest version can be used by setting the following in your config.xml:
 

--- a/blog/build/_posts/2015-09-04-public-plugin-deprecation-on-build.md
+++ b/blog/build/_posts/2015-09-04-public-plugin-deprecation-on-build.md
@@ -6,8 +6,6 @@ author: Ryan Willoughby
 title: "Deprecation of Public Plugins on PhoneGap Build"
 category: build
 ---
-tags:
-- PhoneGap Build
 
 Don't panic! A few months ago [we announced support for building with Cordova plugins from the npm repository](http://phonegap.com/blog/2015/05/26/npm-plugins-available/), and have since been encouraging plugin developers to publish plugins there instead of on Build. We've now disabled submission of public plugins to Build; they must be published to the [npm repository](http://npmjs.com). Users can still continue to build with all of the [existing plugins in the PhoneGap Build repository](https://build.phonegap.com/plugins), but any new plugins, or new versions of existing plugins, must be published to npm. PhoneGap Developers can use [this page](http://plugins.cordova.io/npm/index.html) to find Cordova plugins in the npm repository. In addition we've added a field on the plugin details page where plugin owners can flag plugins as deprecated, and provide the npm package id of the plugin. We highly encourage all plugin owners to do so as soon as possible.
 

--- a/blog/build/_posts/2015-09-23-phonegap_520_now_on_build.md
+++ b/blog/build/_posts/2015-09-23-phonegap_520_now_on_build.md
@@ -6,8 +6,6 @@ author: Ryan Willoughby
 title: "PhoneGap 5.2.0 Now Available on Build"
 category: build
 ---
-tags:
-- PhoneGap Build
 
 PhoneGap 5.2.0 is now available on PhoneGap Build! To use it, add the following to your config.xml:
 

--- a/blog/build/_posts/2015-09-28-android-using-gradle.md
+++ b/blog/build/_posts/2015-09-28-android-using-gradle.md
@@ -6,8 +6,6 @@ author: brettrudd
 title: "Android Builds Now Using Gradle By Default"
 category: build
 ---
-tags:
-- PhoneGap Build
 
 All android builds using any PhoneGap version above 4.0.0 will now use [Gradle](http://www.gradle.org) by default. For **most** users this change will not have an effect. Users who know what this change means and realise the flexibility it provides to plugin authors and users will most likely dance.
 

--- a/blog/build/_posts/2015-11-17-config_xml_update.md
+++ b/blog/build/_posts/2015-11-17-config_xml_update.md
@@ -6,8 +6,6 @@ author: brettrudd
 title: "config.xml gets an update"
 category: build
 ---
-tags:
-- PhoneGap Build
 
 Hey folks, starting today some of you found out config.xml on PhoneGap Build got an update. For most users this will have no change. But for some users who use the Cordova cli you will find your workflow just got easier.
 

--- a/blog/build/_posts/2015-11-19-config_xml_changes_part_two.md
+++ b/blog/build/_posts/2015-11-19-config_xml_changes_part_two.md
@@ -6,8 +6,6 @@ author: brettrudd
 title: "config.xml gets an update - part 2 !!!!!! "
 category: build
 ---
-tags:
-- PhoneGap Build
 
 ## PLEASE NOTE NEW INFO BELOW ABOUT THE PLUGIN AND CONFIG-FILE ELEMENTS !!!
 

--- a/blog/build/_posts/2016-02-09-phonegap_6_now_on_build.md
+++ b/blog/build/_posts/2016-02-09-phonegap_6_now_on_build.md
@@ -6,8 +6,6 @@ author: Ryan Willoughby
 title: "PhoneGap 6.0.0 Now Available on Build"
 category: build
 ---
-tags:
-- PhoneGap Build
 
 PhoneGap 6.0.0 is now available on PhoneGap Build! To use it, add the following to your config.xml:
 

--- a/blog/build/_posts/2016-02-16-git-plugins.md
+++ b/blog/build/_posts/2016-02-16-git-plugins.md
@@ -6,8 +6,6 @@ category: build
 tags:
 - PhoneGap Build
 ---
-tags:
-- PhoneGap Build
 
 Hey folks, we are happy to announce you can now use git-backed **public** plugins on PhoneGap Build.
 


### PR DESCRIPTION
@GarthDB's search and replace added duplicate tags that were showing up in the blog post content. Fixin.